### PR TITLE
partial comparison of arguments

### DIFF
--- a/lib/nodemock.js
+++ b/lib/nodemock.js
@@ -229,7 +229,7 @@ function NodeMock(methodName) {
 			if(actualType == "function") {
 				continue;
 			} else if(actualType == "object") {
-				if(!deepObjectCheck(actual[key], expected[key])) return false;
+				if(!deepObjectCheck(expected[key]	,actual[key])) return false;
 			} else {
 				if(actual[key] != expected[key]) return false;
 			}

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -328,7 +328,6 @@ exports.testPartialCompareBug2 = function (test){
 	})
 	
 	test.done()
-	
 }
 
 exports.testPartialCompare = function (test){
@@ -336,6 +335,11 @@ exports.testPartialCompare = function (test){
 	test.doesNotThrow(function (){
 		var mock = nm.mock('foo').takes({hi: 1},2,3)
 		mock.foo({hi: 1, bye: 2000},2,3) //should throw because bye: 2000 is not present
+	})
+	
+	test.throws(function (){
+		var mock = nm.mock('foo').takes({hi: 1},2,3)
+		mock.foo({},2,3) //should throw because bye: 2000 is not present
 	})
 	
 	test.done()

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -308,3 +308,36 @@ exports.testCtrl = function(test) {
 	
 	test.done();
 };
+
+exports.testPartialCompareBug1 = function (test){
+	
+	test.throws(function (){
+		var mock = nm.mock('foo').takes({hi: 1, bye: 2000},2,3)
+		mock.foo({},2,3) //should throw because bye: 2000 is not present
+	})
+	
+	test.done()
+}
+
+exports.testPartialCompareBug2 = function (test){
+	
+	test.throws(function (){
+		var mock = nm.mock('foo').takes({hi: 1, bye: 2000},2,3)
+		mock.foo({hi: 1},2,3) //should throw because bye: 2000 is not present
+		mock.foo({},2,3) //should throw because bye: 2000 is not present
+	})
+	
+	test.done()
+	
+}
+
+exports.testPartialCompare = function (test){
+	
+	test.doesNotThrow(function (){
+		var mock = nm.mock('foo').takes({hi: 1},2,3)
+		mock.foo({hi: 1, bye: 2000},2,3) //should throw because bye: 2000 is not present
+	})
+	
+	test.done()
+	
+}


### PR DESCRIPTION
sometimes you don't need to check EVERYTHING about an object to know it's correct. especially when the object is likely to change or be added to.

for example, it would be great to be able to do this:

```
var mocked = nm.mock('foo').takes({atLeast: true, andThis: false})

mocked.foo({atLeast: true, andThis:false, ignoreThisExtraStuff: 'whatever'})
```

turns out nodemock already supported this, but in reverse. you could put extra properties in takes({}) and ignore them when the mock was called. 

I've made tests to check for the correct behavior, and then fixed it.

turns out it was just a one line fix.

cheers. Dominic
