### PR TITLE
Possible fix for no support for multiple return values on one mock method

### DIFF
--- a/lib/nodemock.js
+++ b/lib/nodemock.js
@@ -36,6 +36,7 @@ function NodeMock(methodName) {
 		function getValidEntry(args) {
 			
 			var matchingEntries = [];
+			var returnedEntry = false;
 			
 			for(var index in entries[method]) {
 				entry = entries[method][index];
@@ -44,15 +45,18 @@ function NodeMock(methodName) {
 				if(entry.match) {
 					matchingEntries.push(entry);
 				}
-				if(deepObjectCheck(entry.args, args)) {
+				if(entry.executed < entry.expectedExecutions && deepObjectCheck(entry.args, args)) {
 					entry.executed ++;
-					return entry;
+					returnedEntry = entry;
+					break;
+				} else if (deepObjectCheck(entry.args, args)) {
+				  returnedEntry = entry;
 				}
 				//increasing executed numbers for that entry
 			}
 			
 			//start matching
-			return false;
+			return returnedEntry;
 		}
 		
 		return function() {

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -308,3 +308,14 @@ exports.testCtrl = function(test) {
 	
 	test.done();
 };
+
+exports.multiReturn = function(test) {
+  var mock = nm.mock("foo").returns(1);
+  mock.mock("foo").returns(2);
+
+  test.equal(mock.foo(), 1, "good first return");
+  test.equal(mock.foo(), 2, "good second return");
+  
+  test.done();
+}
+

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -310,13 +310,16 @@ exports.testCtrl = function(test) {
 };
 
 exports.multiReturn = function(test) {
-  var mock = nm.mock("foo").returns(1);
-  mock.mock("foo").returns(2);
+	var mock = nm.mock("foo").returns(1);
+	mock.mock("foo").returns(2);
+	mock.mock("foo").takes(1).returns(42);
 
-  test.equal(mock.foo(), 1, "good first return");
-  test.equal(mock.foo(), 2, "good second return");
-  test.ok(mock.assert(), 'bad invoked mocks');
-  
-  test.done();
+	test.equal(mock.foo(), 1, "good first return");
+	test.equal(mock.foo(), 2, "good second return");
+	test.equal(mock.foo(), 2, "re-uses second return");
+	test.equal(mock.foo(1), 42, "still match on arguments");
+	test.ok(mock.assert(), 'bad invoked mocks');
+
+	test.done();
 }
 

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -314,7 +314,8 @@ exports.multiReturn = function(test) {
   mock.mock("foo").returns(2);
 
   test.equal(mock.foo(), 1, "good first return");
-  test.equal(mock.foo(), 2, "good second return");
+  // test.equal(mock.foo(), 2, "good second return");
+  test.ok(mock.assert(), 'bad invoked mocks');
   
   test.done();
 }

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -314,7 +314,7 @@ exports.multiReturn = function(test) {
   mock.mock("foo").returns(2);
 
   test.equal(mock.foo(), 1, "good first return");
-  // test.equal(mock.foo(), 2, "good second return");
+  test.equal(mock.foo(), 2, "good second return");
   test.ok(mock.assert(), 'bad invoked mocks');
   
   test.done();


### PR DESCRIPTION
I changed the way that methods are matched to fix [issue #4](https://github.com/arunoda/nodemock/issues/4) and added a unit test to verify that the change fixes the bug.
