### PR TITLE
Added a callhook method

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Usage
 ### Creating a mock with callback support
 	var mocked = nodemock.mock("foo").takes(20, function(){}).calls(1, [30, 40]);
 	
-	mockes.foo(20, function(num, arr) {
+	mocked.foo(20, function(num, arr) {
 		console.log(num); //prints 30
 		console.log(arr); //prints 40
 	});
@@ -56,6 +56,28 @@ Usage
 		When you invoke foo() nodemock will calls the callback(sits in argument index 1 - as specified)
 		with the parameters 30 and 40 respectively. 
 	*/
+
+### Executing arbitrary function prior to calling the callback
+Sometimes we need to execute code in the testing environment prior to executing the 
+callback but after the mock is called.
+	
+	var doSomething = function(call) {
+		//... do stuff
+		call(); //continue with normal callback support as above
+	};
+	var mocked = nodemock.mock("foo").takes(20, function(){}).callhook( doSomething )
+	  .calls(1, [30, 40]);
+	
+	mocked.foo(20, function(num, arr) {
+		console.log(num); //prints 30
+		console.log(arr); //prints 40
+	});
+
+	/*
+	  doSomething callhook is given call param that you should call if you want
+	  to continue execution as normal and invoke the callback
+	*/
+
 
 ### Controlling callbacks
 With the asynchronous nature of NodeJS(and brower with AJAX too) it'll be great if we can control the execution of the callback in the testing environment. And `ctrl()` of nodemock helps that

--- a/lib/nodemock.js
+++ b/lib/nodemock.js
@@ -83,18 +83,30 @@ function NodeMock(methodName) {
 				throw new Error("You should not call: '" + method+ "()' with params: " + getParamString(arguments) + " on this object");
 			}
 			
-			//calling the callback
-			if(entry.callbackIndex != null) {
-				var func = arguments[entry.callbackIndex];
-				entry.callback = func;
-				
-				if(entry.callbackArgs) {
-					if(typeof(func) == "function") {
-						func.apply(this, entry.callbackArgs || []);
-					} else {
-						throw new Error("Expected callback is not defined as callback");
+			//setup the callback
+			var _arguments = arguments,
+			    _this = this;
+			var _call = function () {
+				//calling the callback
+				if(entry.callbackIndex != null) {
+					var func = _arguments[entry.callbackIndex];
+					entry.callback = func;
+					
+					if(entry.callbackArgs) {
+						if(typeof(func) == "function") {
+							func.apply(_this, entry.callbackArgs || []);
+						} else {
+							throw new Error("Expected callback is not defined as callback");
+						}
 					}
 				}
+			};
+
+			//see if we have a callhook first
+			if(entry.callhook != null) {
+				entry.callhook( _call );
+			} else { //calling the callback
+				_call();
 			}
 			
 			return entry.returns;
@@ -154,6 +166,20 @@ function NodeMock(methodName) {
 			throw new Error("First arg of the calls() should be the index of the callback");
 		}
 	};
+
+	this.callhook = function() {
+		
+		if(typeof(arguments[0]) == "function") {
+			var entry = getCurrentEntry();
+
+			entry.callhook = arguments[0];
+
+			return this;
+		} else {
+			throw new Error("First arg of the callhook() should be a function");
+		}
+
+	};
 	
 	this.assert = function() {
 		
@@ -199,6 +225,7 @@ function NodeMock(methodName) {
 				callback: null,
 				callbackIndex: null,
 				callbackArgs: [],
+				callhook: null,
 				returns: undefined,
 				executed: false, // whether the mock entry executed or not
 				shouldFail: false
@@ -231,6 +258,7 @@ function NodeMock(methodName) {
 			'returns': true,
 			'ctrl': true,
 			'calls': true,
+			'hook': true,
 			'assert': true,
 			'assertThrows': true,
 			'mock': true,

--- a/lib/nodemock.js
+++ b/lib/nodemock.js
@@ -258,7 +258,7 @@ function NodeMock(methodName) {
 			'returns': true,
 			'ctrl': true,
 			'calls': true,
-			'hook': true,
+			'callhook': true,
 			'assert': true,
 			'assertThrows': true,
 			'mock': true,

--- a/test/nodemock.js
+++ b/test/nodemock.js
@@ -186,6 +186,64 @@ exports.testCallbackWithoutArgs = function(test) {
 	test.done();
 };
 
+exports.testCallbackWithCallhook = function(test) {
+	
+	var hook = function(call){
+		call();
+	};
+	var mock = nm.mock("foo").takes(10, function(){}).callhook(hook).calls(1);
+	test.expect(2);
+	mock.foo(10, function(a, b) {
+		test.equals(a, undefined);
+		test.equals(b, undefined);
+	});
+
+	test.done();
+};
+
+exports.testCallbackWithCallhookAndAssertion = function(test) {
+	
+	var mock = nm.mock("foo").takes(10, function(){}).callhook(function(call) {
+		mock.assert();
+		call();
+	}).calls(1);
+	test.expect(2);
+	mock.foo(10, function(a, b) {
+		test.equals(a, undefined);
+		test.equals(b, undefined);
+	});
+
+	test.done();
+};
+
+exports.testCallbackWithCallhookAndFailedAssertion = function(test) {
+	
+	var mock = nm.mock("foo").takes(10, function(){}).callhook(function(call) {
+		mock.assert();
+		call();
+	}).calls(1);
+	test.throws(function() {
+		mock.foo(9, function(a, b) {
+		  test.equals(a, undefined);
+		  test.equals(b, undefined);
+	  });
+	});
+
+	test.done();
+};
+
+exports.testCallbackWithCallhookCallNotFired = function(test) {
+	
+	var mock = nm.mock("foo").takes(10, function(){}).callhook(function(call) {
+		mock.assert();
+	}).calls(1);
+	mock.foo(10, function() {
+		test.fail();
+	});
+
+	test.done();
+};
+
 exports.testMockAgain = function(test) {
 	
 	var mock = nm.mock("foo").takes(10, 20).returns(30);


### PR DESCRIPTION
This is to enable executing code in testing environment after mock is triggered.

Http response use case:

``` javascript
var res = new EventEmitter();
var returnData = function (call) {
  call(); // callback fired
  res.emit( 'data', ... ); // start feeding the response
  //...
  res.emit( 'end' );
};
httpMock.mock( 'request' ).takes( {
  host : 'host',
  port : 80,
  path : '/',
  method : 'GET'
}, function () {} ).returns( reqMock ).callhook( returnData ).calls( 1, [res] );
```

Trigger assertion asynchronously use case:

``` javascript
var res = new EventEmitter();
var verify = function (call) {
  httpMock.assert();
  done(); // some async framework test finish
};
httpMock.mock( 'request' ).takes( {
  host : 'host',
  port : 80,
  path : '/',
  method : 'GET'
}, function () {} ).returns( reqMock ).callhook( verify ).calls( 1, [res] );
```
